### PR TITLE
Add new enum and 3 new utility functions.

### DIFF
--- a/Enums/SubTypes.lua
+++ b/Enums/SubTypes.lua
@@ -117,6 +117,15 @@ TSIL.Enums.HeavenLightDoorSubType = {
   MOONLIGHT = 1,
 }
 
+---@enum GibSubType
+--- For `EntityType.EFFECT` (1000), `EffectVariant.BLOOD_PARTICLE` (5).
+TSIL.Enums.GibSubType = {
+  BLOOD = 0,
+  BONE = 1,
+  GUT = 2,
+  EYE = 3,
+}
+
 ---@enum DiceFloorSubType
 --- For `EntityType.EFFECT` (1000), `EffectVariant.DICE_FLOOR` (76). 
 TSIL.Enums.DiceFloorSubType = {

--- a/Utils/String/EndsWith.lua
+++ b/Utils/String/EndsWith.lua
@@ -1,0 +1,7 @@
+---Helper function to check if a string ends  with a given suffix.
+---@param s string
+---@param suffix string
+---@return boolean
+function TSIL.Utils.String.EndsWith(s, suffix)
+    return string.sub(s, (#s - #suffix) + 1) == suffix
+end

--- a/Utils/String/Split.lua
+++ b/Utils/String/Split.lua
@@ -1,0 +1,14 @@
+---Helper function that splits a string into parts based on the given separator.
+---
+---For example, splitting the string "Hello there, world!" with separator " " will return ["Hello", "there,", "world!"]
+---@param s string
+---@param separator string
+---@return string[]
+function TSIL.Utils.String.Split(s, separator)
+    local result = {}
+    for substring in string.gmatch(s, "([^" .. separator .. "]+)") do
+        table.insert(result, substring)
+    end
+
+    return result
+end

--- a/Utils/String/StartsWith.lua
+++ b/Utils/String/StartsWith.lua
@@ -1,0 +1,7 @@
+---Helper function to check if a string starts with a given prefix.
+---@param s string
+---@param prefix string
+---@return boolean
+function TSIL.Utils.String.StartsWith(s, prefix)
+    return s:sub(1, #prefix) == prefix
+end


### PR DESCRIPTION
Added an enum about gib subtypes. I'll be honest, I didn't realize until right before I created this pull request that "gibs" is not an actual synonym for guts, but a gaming slang term. Feel free to rename that.

Added 3 new string-related utility functions:
- `Split` - Split a string into an array based on a given separator.
- `EndsWith` - Returns a boolean denoting if a string ends with a given suffix.
- `StartsWith` - Returns a boolean denoting if a string starts with a given prefix.

They're all pretty useful for implementing custom commands.